### PR TITLE
superappium 截图透明黑底问题

### DIFF
--- a/base-lib-ratel-extension/src/main/java/com/virjar/ratel/api/extension/superappium/sekiro/ScreenShotHandler.java
+++ b/base-lib-ratel-extension/src/main/java/com/virjar/ratel/api/extension/superappium/sekiro/ScreenShotHandler.java
@@ -82,13 +82,13 @@ public class ScreenShotHandler implements SekiroRequestHandler {
                     return;
                 }
 
-                Bitmap bitmap = Bitmap.createBitmap(decorView.getWidth(), decorView.getHeight(), Bitmap.Config.RGB_565);
+                Bitmap bitmap = Bitmap.createBitmap(decorView.getWidth(), decorView.getHeight(), Bitmap.Config.ARGB_8888);
                 decorView.draw(new Canvas(bitmap));
 
                 ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                bitmap.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream);
+                bitmap.compress(Bitmap.CompressFormat.PNG, quality, byteArrayOutputStream);
 
-                sekiroResponse.send("image/jpeg", byteArrayOutputStream.toByteArray());
+                sekiroResponse.send("image/png", byteArrayOutputStream.toByteArray());
             }
 
 


### PR DESCRIPTION
如果需要截图的部分为透明背景黑色文字，原有截图方式会把透明处理为黑色，这样截图部分黑色文字就无法正常显示。修改使用PNG截图方式。